### PR TITLE
Fix cyclic imports in generated code

### DIFF
--- a/types/definition.go
+++ b/types/definition.go
@@ -2,14 +2,19 @@ package types
 
 import (
 	"github.com/clear-street/gogen-avro/generator"
+	"github.com/clear-street/gogen-avro/imprt"
 )
+
+type HasAvroName interface {
+	AvroName() QualifiedName
+}
 
 /*
   The definition of a record, fixed or enum satisfies this interface.
 */
 
 type Definition interface {
-	AvroName() QualifiedName
+	HasAvroName
 	Aliases() []QualifiedName
 
 	// A user-friendly name that can be built into a Go string (for unions, mostly)
@@ -31,4 +36,11 @@ type Definition interface {
 	// A JSON object defining this object, for writing the schema back out
 	Definition(scope map[QualifiedName]interface{}) (interface{}, error)
 	DefaultValue(lvalue string, rvalue interface{}) (string, error)
+}
+
+//Contains returns whether the package contains the definition
+func Contains(p *generator.Package, def HasAvroName) bool {
+	pkgPath := imprt.Path(p.Root(), p.Name())
+	defPath := imprt.Path(p.Root(), def.AvroName().Namespace)
+	return pkgPath == defPath
 }

--- a/types/enum.go
+++ b/types/enum.go
@@ -127,7 +127,7 @@ func (e *EnumDefinition) serializerMethodDef(p *generator.Package) string {
 }
 
 func (e *EnumDefinition) SerializerMethod(p *generator.Package) string {
-	if p.Name() != e.AvroName().Namespace {
+	if !Contains(p, e) {
 		pkg := imprt.Pkg(p.Root(), e.AvroName().Namespace)
 		return fmt.Sprintf("%s.Write%s", pkg, e.GoType())
 	}
@@ -139,7 +139,7 @@ func (e *EnumDefinition) deserializerMethodDef(p *generator.Package) string {
 }
 
 func (e *EnumDefinition) DeserializerMethod(p *generator.Package) string {
-	if p.Name() != e.AvroName().Namespace {
+	if !Contains(p, e) {
 		pkg := imprt.Pkg(p.Root(), e.AvroName().Namespace)
 		return fmt.Sprintf("%s.Read%s", pkg, e.GoType())
 	}
@@ -163,7 +163,7 @@ func (e *EnumDefinition) AddStruct(p *generator.Package, _ bool) error {
 }
 
 func (e *EnumDefinition) AddSerializer(p *generator.Package) {
-	if p.Name() != e.AvroName().Namespace {
+	if !Contains(p, e) {
 		p.AddImport(UTIL_FILE, imprt.Path(p.Root(), e.AvroName().Namespace))
 		return
 	}
@@ -176,7 +176,7 @@ func (e *EnumDefinition) AddSerializer(p *generator.Package) {
 }
 
 func (e *EnumDefinition) AddDeserializer(p *generator.Package) {
-	if p.Name() != e.AvroName().Namespace {
+	if !Contains(p, e) {
 		p.AddImport(UTIL_FILE, imprt.Path(p.Root(), e.AvroName().Namespace))
 		return
 	}

--- a/types/record.go
+++ b/types/record.go
@@ -104,7 +104,7 @@ func (r *RecordDefinition) structFields(p *generator.Package) string {
 			fieldDefinitions += fmt.Sprintf("\n// %v\n", f.Doc())
 		}
 
-		if ref, ok := f.avroType.(*Reference); ok && ref.AvroName().Namespace != r.AvroName().Namespace {
+		if ref, ok := f.avroType.(*Reference); ok && !Contains(p, ref) {
 			t := imprt.Type(p.Root(), ref.AvroName().Namespace, f.Type().GoType())
 			fieldDefinitions += fmt.Sprintf("%v %v\n", f.GoName(), t)
 		} else {
@@ -147,7 +147,7 @@ func (r *RecordDefinition) deserializerMethodDef(p *generator.Package) string {
 }
 
 func (r *RecordDefinition) SerializerMethod(p *generator.Package) string {
-	if p.Name() != r.AvroName().Namespace {
+	if !Contains(p, r) {
 		pkg := imprt.Pkg(p.Root(), r.AvroName().Namespace)
 		return fmt.Sprintf("%s.Write%s", pkg, r.Name())
 	}
@@ -156,7 +156,7 @@ func (r *RecordDefinition) SerializerMethod(p *generator.Package) string {
 }
 
 func (r *RecordDefinition) DeserializerMethod(p *generator.Package) string {
-	if p.Name() != r.AvroName().Namespace {
+	if !Contains(p, r) {
 		pkg := imprt.Pkg(p.Root(), r.AvroName().Namespace)
 		return fmt.Sprintf("%s.Read%s", pkg, r.Name())
 	}
@@ -204,7 +204,7 @@ func (r *RecordDefinition) qualifiedNameMethodDef() (string, error) {
 }
 
 func (r *RecordDefinition) AddStruct(p *generator.Package, containers bool) error {
-	if p.Name() != r.AvroName().Namespace {
+	if !Contains(p, r) {
 		return nil
 	}
 
@@ -224,7 +224,7 @@ func (r *RecordDefinition) AddStruct(p *generator.Package, containers bool) erro
 
 		for _, f := range r.fields {
 			ref, ok := f.avroType.(*Reference)
-			if !ok || ref.AvroName().Namespace == r.AvroName().Namespace {
+			if !ok || Contains(p, ref) {
 				continue
 			}
 			p.AddImport(r.filename(), imprt.Path(p.Root(), ref.AvroName().Namespace))
@@ -254,7 +254,7 @@ func (r *RecordDefinition) AddStruct(p *generator.Package, containers bool) erro
 }
 
 func (r *RecordDefinition) AddSerializer(p *generator.Package) {
-	if p.Name() != r.AvroName().Namespace {
+	if !Contains(p, r) {
 		p.AddImport(UTIL_FILE, imprt.Path(p.Root(), r.AvroName().Namespace))
 		return
 	}
@@ -271,7 +271,7 @@ func (r *RecordDefinition) AddSerializer(p *generator.Package) {
 }
 
 func (r *RecordDefinition) AddDeserializer(p *generator.Package) {
-	if p.Name() != r.AvroName().Namespace {
+	if !Contains(p, r) {
 		p.AddImport(UTIL_FILE, imprt.Path(p.Root(), r.AvroName().Namespace))
 		return
 	}

--- a/types/schema.go
+++ b/types/schema.go
@@ -3,7 +3,6 @@ package types
 import (
 	"encoding/json"
 	"fmt"
-	"reflect"
 	"strings"
 
 	"github.com/clear-street/gogen-avro/generator"
@@ -65,43 +64,9 @@ func (namespace *Namespace) AddToPackage(p *generator.Package, headerComment str
 
 // RegisterDefinition adds a new type definition to the namespace. Returns an error if the type is already defined.
 func (n *Namespace) RegisterDefinition(d Definition) error {
-	if curDef, ok := n.Definitions[d.AvroName()]; ok {
-		if !reflect.DeepEqual(curDef, d) {
-
-			//Ugly (and hopefully temporary) workaround for this: https://github.com/actgardner/gogen-avro/issues/34#issuecomment-485135439
-			enum1, ok1 := curDef.(*EnumDefinition)
-			enum2, ok2 := d.(*EnumDefinition)
-			if !ok1 || !ok2 {
-				return fmt.Errorf("Conflicting definitions for %v", d.AvroName())
-			}
-			emptyScope := make(map[QualifiedName]interface{})
-			def1, err := enum1.Definition(emptyScope)
-			if err != nil {
-				panic(err)
-			}
-			def2, err := enum2.Definition(emptyScope)
-			if err != nil {
-				panic(err)
-			}
-			map1, ok := def1.(map[string]interface{})
-			if !ok {
-				panic("failed to cast def1 to map")
-			}
-			map2, ok := def2.(map[string]interface{})
-			if !ok {
-				panic("failed to cast def2 to map")
-			}
-			if map1["namespace"] == nil && map2["namespace"] != nil {
-				map1["namespace"] = map2["namespace"]
-			} else if map1["namespace"] != nil && map2["namespace"] == nil {
-				map2["namespace"] = map1["namespace"]
-			} else {
-				return fmt.Errorf("Conflicting definitions for enum %v", d.AvroName())
-			}
-			if !reflect.DeepEqual(curDef, d) {
-				return fmt.Errorf("Enum %v has conflicting definitions", d.AvroName())
-			}
-		}
+	if _, ok := n.Definitions[d.AvroName()]; ok {
+		fmt.Printf("Ignoring duplicate definition- %v\n", d.AvroName())
+		return nil
 	}
 	n.Definitions[d.AvroName()] = d
 

--- a/types/union.go
+++ b/types/union.go
@@ -77,7 +77,7 @@ func (s *unionField) unionEnumType() string {
 func (s *unionField) unionEnumDef(p *generator.Package) string {
 	var unionTypes string
 	for i, item := range s.itemType {
-		if ref, ok := item.(*Reference); ok && ref.AvroName().Namespace != p.Name() {
+		if ref, ok := item.(*Reference); ok && !Contains(p, ref) {
 			name := imprt.UniqName(p.Root(), ref.AvroName().Namespace, item.Name())
 			unionTypes += fmt.Sprintf("%v %v = %v\n", s.unionEnumType()+name, s.unionEnumType(), i)
 		} else {
@@ -91,7 +91,7 @@ func (s *unionField) unionStringerMethodDef(p *generator.Package) string {
 	var cases string
 	for _, item := range s.itemType {
 		name := item.Name()
-		if ref, ok := item.(*Reference); ok && ref.AvroName().Namespace != p.Name() {
+		if ref, ok := item.(*Reference); ok && !Contains(p, ref) {
 			name = imprt.UniqName(p.Root(), ref.AvroName().Namespace, name)
 		}
 
@@ -112,7 +112,7 @@ func (s *unionField) unionStringerMethodDef(p *generator.Package) string {
 func (s *unionField) unionTypeDef(p *generator.Package) string {
 	var unionFields string
 	for _, i := range s.itemType {
-		if ref, ok := i.(*Reference); ok && ref.AvroName().Namespace != p.Name() {
+		if ref, ok := i.(*Reference); ok && !Contains(p, ref) {
 			unionFields += fmt.Sprintf("%v %v\n", imprt.UniqName(p.Root(), ref.AvroName().Namespace, i.Name()), imprt.Type(p.Root(), ref.AvroName().Namespace, i.GoType()))
 		} else {
 			unionFields += fmt.Sprintf("%v %v\n", i.Name(), i.GoType())
@@ -125,7 +125,7 @@ func (s *unionField) unionTypeDef(p *generator.Package) string {
 func (s *unionField) unionSetMethodDef(p *generator.Package, u AvroType) string {
 	t := u.GoType()
 	n := u.Name()
-	if ref, ok := u.(*Reference); ok && ref.AvroName().Namespace != p.Name() {
+	if ref, ok := u.(*Reference); ok && !Contains(p, ref) {
 		t = imprt.Type(p.Root(), ref.AvroName().Namespace, t)
 		n = imprt.UniqName(p.Root(), ref.AvroName().Namespace, n)
 	}
@@ -140,7 +140,7 @@ func (s *unionField) unionSetMethodDef(p *generator.Package, u AvroType) string 
 
 func (s *unionField) unionIdentityMethodDef(p *generator.Package, u AvroType) string {
 	n := u.Name()
-	if ref, ok := u.(*Reference); ok && ref.AvroName().Namespace != p.Name() {
+	if ref, ok := u.(*Reference); ok && !Contains(p, ref) {
 		n = imprt.UniqName(p.Root(), ref.AvroName().Namespace, n)
 	}
 
@@ -155,7 +155,7 @@ func (s *unionField) unionSerializer(p *generator.Package) string {
 	switchCase := ""
 	for _, t := range s.itemType {
 		n := t.Name()
-		if ref, ok := t.(*Reference); ok && ref.AvroName().Namespace != p.Name() {
+		if ref, ok := t.(*Reference); ok && !Contains(p, ref) {
 			n = imprt.UniqName(p.Root(), ref.AvroName().Namespace, n)
 		}
 		switchCase += fmt.Sprintf("case %v:\nreturn %v(r.%v, w)\n", s.unionEnumType()+n, t.SerializerMethod(p), n)
@@ -167,7 +167,7 @@ func (s *unionField) unionDeserializer(p *generator.Package) string {
 	switchCase := ""
 	for _, t := range s.itemType {
 		n := t.Name()
-		if ref, ok := t.(*Reference); ok && ref.AvroName().Namespace != p.Name() {
+		if ref, ok := t.(*Reference); ok && !Contains(p, ref) {
 			n = imprt.UniqName(p.Root(), ref.AvroName().Namespace, n)
 		}
 		switchCase += fmt.Sprintf("case %v:\nval, err :=  %v(r)\nif err != nil {return unionStr, err}\nunionStr.%v = val\n", s.unionEnumType()+n, t.DeserializerMethod(p), n)
@@ -206,7 +206,7 @@ func (s *unionField) AddStruct(p *generator.Package, containers bool) error {
 	}
 
 	for _, f := range s.itemType {
-		if ref, ok := f.(*Reference); ok && ref.AvroName().Namespace != p.Name() {
+		if ref, ok := f.(*Reference); ok && !Contains(p, ref) {
 			p.AddImport(s.filename(), imprt.Path(p.Root(), ref.AvroName().Namespace))
 		}
 	}


### PR DESCRIPTION
The code compared the avro namespace name instead of the actual package's path, generating imports to the same package which fails the compiler.